### PR TITLE
Used fixed locale for gcc invocation

### DIFF
--- a/source/clang/package.d
+++ b/source/clang/package.d
@@ -76,7 +76,7 @@ string[] systemPaths() @safe {
     import std.algorithm: map, countUntil;
     import std.array: array;
 
-    const res = execute(["gcc", "-v", "-xc", "/dev/null", "-fsyntax-only"]);
+    const res = execute(["gcc", "-v", "-xc", "/dev/null", "-fsyntax-only"], ["LANG": "C"]);
     if(res.status != 0) throw new Exception("Failed to call gcc:\n" ~ res.output);
 
     auto lines = res.output.splitLines;


### PR DESCRIPTION
gcc's output is locale dependent, which can break the parser.