### PR TITLE
Supports osx

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,7 +5,8 @@ copyright "Copyright © 2018, Atila Neves"
 license "BSD 3-clause"
 targetType "library"
 libs "clang"
-lflags "-L/usr/lib/llvm-3.9/lib"  # travis
+lflags "-L/usr/local/opt/llvm/lib" platform="osx"
+lflags "-L/usr/lib/llvm-3.9/lib" platform="posix"  # travis
 
 configuration "library" {
 


### PR DESCRIPTION
Brew puts the libs here.
Not sure if other packagers/manual installers would go elsewhere.

```
cgrogan:libclang (master*) $ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.12.6
BuildVersion:   16G1114
cgrogan:libclang (master*) $ dub test
Package unit-threaded can be upgraded from 0.7.40 to 0.7.43.
Use "dub upgrade" to perform those changes.
Running custom 'unittest' configuration.
Performing "unittest" build using /Library/D/dmd/bin/dmd for x86_64.
unit-threaded 0.7.40: target for configuration "library" is up to date.
libclang 0.0.2+commit.1.gc810021: target for configuration "unittest" is up to date.
To force a rebuild of up-to-date targets, run again with --force.
Running ./bin/ut
parse.cooked.Function return type should have valid cx:
parse.cooked.foreach(cursor) C++ file with one simple struct:
parse.cooked.foreach(cursor, parent) C++ file with one simple struct:
parse.cooked.visitChildren C++ file with one simple struct:
parse.cooked.cursor.children C++ file with one simple struct:
ut.enum_.CXAvailabilityKind:
ut.enum_.CXCursor_ExceptionSpecificationKind:
ut.enum_.CXDiagnosticSeverity:
ut.enum_.CXGlobalOptFlags:
wrap.unittest0:
parse.cooked.visitChildren C++ file with one simple struct and throwing visitor:
parse.raw.C++ file with one simple struct and throwing visitor:
parse.raw.C++ file with one simple struct:

Time taken: 22 ms, 855 μs, and 3 hnsecs
13 test(s) run, 0 failed.

OK!

```