### PR TITLE
Windows support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ libclang
 
 
 Bindings / wrapper API for libclang in the [D programming language](https://dlang.org).
+
+
+Build Instructions
+------------------
+
+### Windows
+
+1. Install http://releases.llvm.org/6.0.1/LLVM-6.0.1-win64.exe into `C:\Program Files\LLVM\`, making sure to tick the "Add LLVM to the system PATH for all users" option.
+2. Compile with LDC
+    1. Make sure you have [LDC](https://github.com/ldc-developers/ldc/releases) installed somewhere.
+    2. Compile your project with `dub build --compiler=C:\path\to\bin\ldc2.exe`.
+3. Copy `C:\Program Files\LLVM\bin\libclang.dll` next to your executable.

--- a/dub.sdl
+++ b/dub.sdl
@@ -3,9 +3,11 @@ description "libclang bindings / wrappers for D"
 authors "Atila Neves"
 copyright "Copyright © 2018, Atila Neves"
 license "BSD 3-clause"
-libs "clang"
+libs "clang" platform="posix"
+libs "libclang" platform="windows"
 lflags "-L/usr/local/opt/llvm/lib" platform="osx"
 lflags "-L/usr/lib/llvm-3.9/lib" platform="posix"  # travis
+lflags "/LIBPATH:C:\\PROGRA~1\\LLVM\\lib" platform="windows"
 
 
 configuration "library" {


### PR DESCRIPTION
Fixes dpp issues #80 and #86. Will provide another PR to dpp as well.

I got unresolved symbols when compiling with dmd mscoff, so I think LDC is a requirement. Apparently, on Windows `lib` is not prepended to `clang` in the dub `libs` entry.

When `clang` is not in the path, `execute` throws before `(res.status != 0)` can be checked, resulting in the uninformative message
```
Failed to spawn new process (The system cannot find the file specified.)
```
Now, by means of the lambda-wrapped `try`/`catch`, we get the context of the error as well:
```
Error: Failed to call clang:
Failed to spawn new process (The system cannot find the file specified.)
```

I had preferred to use `ifThrown` instead of the lambda, but that's not yet possible in `@safe` code due to  https://issues.dlang.org/show_bug.cgi?id=19741.