### PR TITLE
Get C++ destructor name on Windows better

### DIFF
--- a/source/clang/package.d
+++ b/source/clang/package.d
@@ -182,10 +182,16 @@ string toString(CXString cxString) @safe pure nothrow {
 }
 
 string[] toStrings(CXStringSet* strings) @trusted pure nothrow {
+    import std.conv: to;
     scope(exit) clang_disposeStringSet(strings);
     string[] ret;
-    foreach(cxstr; strings.Strings[0 .. strings.Count])
-        ret ~= cxstr.toString;
+    foreach(cxstr; strings.Strings[0 .. strings.Count]) {
+        // cannot use the toString above since it frees, and so
+        // does the dispose string set at scope exit, leading to
+        // a double free situation
+        auto cstr = clang_getCString(cxstr);
+        ret ~= cstr.to!string;
+    }
     return ret;
 }
 

--- a/source/clang/package.d
+++ b/source/clang/package.d
@@ -340,7 +340,23 @@ struct Cursor {
     }
 
     string mangling() @safe pure nothrow const {
-        return clang_Cursor_getMangling(cx).toString;
+        string mangle;
+        // for destructors, there may be multiple mangles,
+        // and the getMangling function doesn't always return
+        // the right one. To be honest, I don't know how to find
+        // the right one all the time, but in testing, the first
+        // one on this function, if it returns one, works more often.
+        // I wish I could explain more, I just know this passes the tests
+        // and the plain impl of just getMangling doesn't.
+        auto otherMangles = clang_Cursor_getCXXManglings(cx);
+        if(otherMangles) {
+            auto strings = toStrings(otherMangles);
+            if(strings.length)
+                mangle = strings[0];
+        }
+        if(mangle is null)
+            mangle = clang_Cursor_getMangling(cx).toString;
+        return mangle;
     }
 
     bool isAnonymous() @safe @nogc pure nothrow const {


### PR DESCRIPTION
See the commit messages and code - it just passes the tests but I'm not 100% sure this is actually the right thing to do.

It also passed the tests on Linux still, so I believe no regression...