### PR TITLE
Lazy SourceLocation member variables in SourceRange

### DIFF
--- a/source/clang/util.d
+++ b/source/clang/util.d
@@ -1,0 +1,35 @@
+module clang.util;
+
+
+mixin template Lazy(alias memberVariable) {
+
+    import std.format: format;
+
+    private enum id = __traits(identifier, memberVariable);
+    static assert(id[0] == '_',
+                  "`" ~ id ~ "` does not start with an underscore");
+
+    private enum initVar = id ~ `Init`;
+    mixin(`bool `, initVar, `;`);
+
+    private enum str = q{
+            ref %s()() @property const {
+                import std.traits: Unqual;
+                if(!%s) {
+                    () @trusted { cast(bool) %s = true; }();
+                    () @trusted { cast(Unqual!(typeof(%s))) %s = %s; }();
+                }
+                return %s;
+            }
+        }.format(
+            id[1..$],
+            initVar,
+            initVar,
+            id, id, id ~ `Create`,
+            id,
+        )
+    ;
+
+    //pragma(msg, str);
+    mixin(str);
+}

--- a/tests/parse/sourcerange.d
+++ b/tests/parse/sourcerange.d
@@ -34,7 +34,10 @@ import clang;
         function_.sourceRange.start.path.should == inSandboxPath("foo.cpp");
         function_.sourceRange.start.line.should == 2;
         function_.sourceRange.start.column.should == 33;
-        function_.sourceRange.start.offset.should == 33;
+        version(Windows)
+            function_.sourceRange.start.offset.should == 34;
+        else
+            function_.sourceRange.start.offset.should == 33;
     }
 }
 
@@ -53,6 +56,9 @@ import clang;
         function_.sourceRange.end.path.should == inSandboxPath("foo.cpp");
         function_.sourceRange.end.line.should == 2;
         function_.sourceRange.end.column.should == 56;
-        function_.sourceRange.end.offset.should == 56;
+        version(Windows)
+            function_.sourceRange.end.offset.should == 57;
+        else
+            function_.sourceRange.end.offset.should == 56;
     }
 }

--- a/tests/parse/sourcerange.d
+++ b/tests/parse/sourcerange.d
@@ -1,0 +1,58 @@
+module parse.sourcerange;
+
+
+import test.infra;
+import clang;
+
+
+@("path")
+@safe unittest {
+    import clang.c.index: CXType_Pointer;
+    with(NewTranslationUnit("foo.cpp",
+                            q{
+                                const char* newString();
+                            }))
+    {
+        const cursor = translUnit.cursor;
+        const function_ = cursor.children[0];
+        function_.sourceRange.path.should == inSandboxPath("foo.cpp");
+    }
+}
+
+
+@("start")
+@safe unittest {
+    import clang.c.index: CXType_Pointer;
+    with(NewTranslationUnit("foo.cpp",
+                            q{
+                                const char* newString();
+                            }))
+    {
+        const cursor = translUnit.cursor;
+        const function_ = cursor.children[0];
+
+        function_.sourceRange.start.path.should == inSandboxPath("foo.cpp");
+        function_.sourceRange.start.line.should == 2;
+        function_.sourceRange.start.column.should == 33;
+        function_.sourceRange.start.offset.should == 33;
+    }
+}
+
+
+@("end")
+@safe unittest {
+    import clang.c.index: CXType_Pointer;
+    with(NewTranslationUnit("foo.cpp",
+                            q{
+                                const char* newString();
+                            }))
+    {
+        const cursor = translUnit.cursor;
+        const function_ = cursor.children[0];
+
+        function_.sourceRange.end.path.should == inSandboxPath("foo.cpp");
+        function_.sourceRange.end.line.should == 2;
+        function_.sourceRange.end.column.should == 56;
+        function_.sourceRange.end.offset.should == 56;
+    }
+}

--- a/tests/ut_main.d
+++ b/tests/ut_main.d
@@ -6,6 +6,7 @@ int main(string[] args) {
     return args.runTests!(
         "parse.raw",
         "parse.cooked",
+        "parse.sourcerange",
         "wrap",
         "ut.enum_",
     );


### PR DESCRIPTION
SourceRange now constructs its `start` and `end` variables on demand, abusing
undefined behaviour by casting away `const`.

See #11 