### PR TITLE
Remove functions from mixed-in templates

### DIFF
--- a/source/clang/c/util.d
+++ b/source/clang/c/util.d
@@ -11,42 +11,21 @@ module clang.c.util;
    Enum.foo and Enum.bar
  */
 mixin template EnumC(T) if(is(T == enum)) {
-
-    private string _enumMixinStr(string member) {
-        import std.conv: text;
-        return text(`enum `, member, ` = `, T.stringof, `.`, member, `;`);
-    }
-
     static foreach(member; __traits(allMembers, T)) {
-        mixin(_enumMixinStr(member));
+        mixin(`enum `, member, ` = `, T.stringof, `.`, member, `;`);
     }
 }
 
 
 mixin template EnumD(string name, T, string prefix) if(is(T == enum)) {
+    import std.conv: text;
+    import std.algorithm : map;
+    import std.format : format;
 
-    private static string _memberMixinStr(string member) {
-        import std.conv: text;
-        import std.array: replace;
-        return text(`    `, member.replace(prefix, ""), ` = `, T.stringof, `.`, member, `,`);
-    }
-
-    private static string _enumMixinStr() {
-        import std.array: join;
-
-        string[] ret;
-
-        ret ~= "enum " ~ name ~ "{";
-
-        static foreach(member; __traits(allMembers, T)) {
-            ret ~= _memberMixinStr(member);
-        }
-
-        ret ~= "}";
-
-        return ret.join("\n");
-    }
-
-    //pragma(msg, _enumMixinStr);
-    mixin(_enumMixinStr());
+    mixin(
+q{enum %s {
+    %-(%s,
+    %),
+}}.format(name, [ __traits(allMembers, T) ].map!(
+             (string v) => text(v[prefix.length .. $], " = ", T.stringof, ".", v))));
 }


### PR DESCRIPTION
Those functions would be affected by the 'extern(C):' used at the top
of the module mixin them in, triggering warnings from the compiler,
such as:
```
.dub/packages/libclang-0.2.5/libclang/source/clang/c/util.d(15,20): Warning: skipping definition of function `clang.c.index.EnumC!(CXCursor_ExceptionSpecificationKind)._enumMixinStr` due to previous definition for the same mangled name: _enumMixinStr
.dub/packages/libclang-0.2.5/libclang/source/clang/c/util.d(15,20): Warning: skipping definition of function `clang.c.index.EnumC!(CXGlobalOptFlags)._enumMixinStr` due to previous definition for the same mangled name: _enumMixinStr
.dub/packages/libclang-0.2.5/libclang/source/clang/c/util.d(15,20): Warning: skipping definition of function `clang.c.index.EnumC!(CXDiagnosticSeverity)._enumMixinStr` due to previous definition for the same mangled name: _enumMixinStr
.dub/packages/libclang-0.2.5/libclang/source/clang/c/util.d(15,20): Warning: skipping definition of function `clang.c.index.EnumC!(CXLoadDiag_Error)._enumMixinStr` due to previous definition for the same mangled name: _enumMixinStr
.dub/packages/libclang-0.2.5/libclang/source/clang/c/util.d(15,20): Warning: skipping definition of function `clang.c.index.EnumC!(CXDiagnosticDisplayOptions)._enumMixinStr` due to previous definition for the same mangled name: _enumMixinStr
.dub/packages/libclang-0.2.5/libclang/source/clang/c/util.d(15,20): Warning: skipping definition of function `clang.c.index.EnumC!(CXTranslationUnit_Flags)._enumMixinStr` due to previous definition for the same mangled name: _enumMixinStr
```