### PR TITLE
Fix memory leaks in TranslationUnit and CXIndex

### DIFF
--- a/source/clang/c/index.d
+++ b/source/clang/c/index.d
@@ -1487,7 +1487,7 @@ int clang_saveTranslationUnit(
 /**
  * \brief Destroy the specified CXTranslationUnit object.
  */
-void clang_disposeTranslationUnit(CXTranslationUnit);
+void clang_disposeTranslationUnit(CXTranslationUnit) @trusted @nogc pure nothrow;
 /**
  * \brief Flags that control the reparsing of translation units.
  *

--- a/source/clang/c/index.d
+++ b/source/clang/c/index.d
@@ -262,7 +262,7 @@ CXIndex clang_createIndex(
  * The index must not be destroyed until all of the translation units created
  * within that index have been destroyed.
  */
-void clang_disposeIndex(CXIndex index);
+void clang_disposeIndex(CXIndex index) @trusted @nogc pure nothrow;
 
 enum CXGlobalOptFlags {
   /**

--- a/source/clang/package.d
+++ b/source/clang/package.d
@@ -38,6 +38,7 @@ TranslationUnit parse(in string fileName,
     const excludeDeclarationsFromPCH = 0;
     const displayDiagnostics = 0;
     auto index = clang_createIndex(excludeDeclarationsFromPCH, displayDiagnostics);
+    scope(exit) clang_disposeIndex(index);
     CXUnsavedFile[] unsavedFiles;
     const commandLineArgz = commandLineArgs
         .map!(a => a.toStringz)

--- a/source/clang/package.d
+++ b/source/clang/package.d
@@ -130,6 +130,10 @@ struct TranslationUnit {
         this.cursor = Cursor(clang_getTranslationUnitCursor(cx));
     }
 
+    ~this() @safe @nogc pure nothrow {
+        clang_disposeTranslationUnit(cx);
+    }
+
     string spelling() @safe pure nothrow const {
         return clang_getTranslationUnitSpelling(cx).toString;
     }


### PR DESCRIPTION
Fixes #26 

This fixes the memory leaks caused by not disposing of `TranslationUnit` and `CXIndex`. 
