### PR TITLE
Fix linking on Debian/Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
+          - ubuntu-22.04
           - windows-2022
           - macos-10.15
         dc:
@@ -40,14 +41,18 @@ jobs:
         with:
           compiler: ${{ matrix.dc }}
 
-      - name: Setup C++
+      - name: 'Non-Linux: Setup C++'
+        if: runner.os != 'Linux'
         uses: aminya/setup-cpp@v1
         with:
           llvm: ${{ matrix.clang }}
+      - name: 'Linux: Install libclang-dev apt package'
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libclang-dev
 
       - name: Run tests
         run: dub test -q --build=unittest-cov --arch=${{ matrix.arch }}
         env:
-          LIBRARY_PATH: "${{ env.LLVM_PATH }}/lib"
+          LIBRARY_PATH: ${{ runner.os != 'Linux' && format('{0}/lib', env.LLVM_PATH) || '' }}
 
       - uses: codecov/codecov-action@v3

--- a/dub.sdl
+++ b/dub.sdl
@@ -9,6 +9,8 @@ libs "libclang" platform="windows"
 
 lflags "-L/usr/local/opt/llvm/lib" platform="osx"
 lflags "/LIBPATH:C:\\PROGRA~1\\LLVM\\lib" platform="windows"
+# unversioned libclang.so symlink on Debian/Ubuntu:
+lflags "-L/usr/lib/llvm-20/lib" "-L/usr/lib/llvm-19/lib" "-L/usr/lib/llvm-18/lib" "-L/usr/lib/llvm-17/lib" "-L/usr/lib/llvm-16/lib" "-L/usr/lib/llvm-15/lib" "-L/usr/lib/llvm-14/lib" "-L/usr/lib/llvm-13/lib" "-L/usr/lib/llvm-12/lib" "-L/usr/lib/llvm-11/lib" "-L/usr/lib/llvm-10/lib" "-L/usr/lib/llvm-9/lib" "-L/usr/lib/llvm-8/lib" "-L/usr/lib/llvm-7/lib" "-L/usr/lib/llvm-6.0/lib" platform="linux"
 
 
 configuration "library" {


### PR DESCRIPTION
Which don't have the expected unversioned `libclang.so` symlink in the default lib dirs. I've added the dirs up to LLVM v20 (current version is 15) for some future-proofness.

Tested manually on Ubuntu 22, works (v14).