### PR TITLE
Leak fix

### DIFF
--- a/pretranslated/14/index.d
+++ b/pretranslated/14/index.d
@@ -69,7 +69,16 @@ alias CXIndex = void*;
 /**
  * \brief A single translation unit, which resides in an index.
  */
-struct CXTranslationUnitImpl;
+struct CXTranslationUnitImpl {
+    void* CIdx;
+    void* TheASTUnit;
+    void* StringPool;
+    void* Diagnostics;
+    void* OverridenCursorsPool;
+    void* CommentToXML;
+    uint ParsingOptions;
+    void* Arguments;
+};
 alias CXTranslationUnit = CXTranslationUnitImpl*;
 
 /**

--- a/pretranslated/15/index.d
+++ b/pretranslated/15/index.d
@@ -122,7 +122,16 @@ alias CXTargetInfo = CXTargetInfoImpl*;
 /**
  * A single translation unit, which resides in an index.
  */
-struct CXTranslationUnitImpl;
+struct CXTranslationUnitImpl {
+    void* CIdx;
+    void* TheASTUnit;
+    void* StringPool;
+    void* Diagnostics;
+    void* OverridenCursorsPool;
+    void* CommentToXML;
+    uint ParsingOptions;
+    void* Arguments;
+};
 alias CXTranslationUnit = CXTranslationUnitImpl*;
 
 /**

--- a/source/clang/package.d
+++ b/source/clang/package.d
@@ -247,8 +247,6 @@ struct Cursor {
         this._spelling = spelling;
         this._spellingInit = true;
         this.type = type;
-
-        this.trUnit = fetchTranslationUnit();
     }
 
     this()(ref return Cursor s) @safe @nogc pure nothrow {

--- a/source/clang/package.d
+++ b/source/clang/package.d
@@ -451,6 +451,10 @@ struct Cursor {
         return Cursor(clang_getSpecializedCursorTemplate(cx));
     }
 
+    TranslationUnit translationUnit() @safe nothrow {
+        return trUnit;
+    }
+
     Language translationUnitLanguage() @safe pure nothrow const {
         return fileNameToLanguage(clang_getTranslationUnitSpelling(clang_Cursor_getTranslationUnit(cx)).toString);
     }


### PR DESCRIPTION
I think this is the reason of crashes:

clang_disposeIndex() - Destroy the given index.

**The index must not be destroyed until all of the translation units created within that index have been destroyed.**
